### PR TITLE
Concatenate attribute content

### DIFF
--- a/lib/generator/h-tag.js
+++ b/lib/generator/h-tag.js
@@ -28,7 +28,19 @@ function parseAttribute(attr, transform) {
 
     if (attr.type === 'PairAttribute') {
         if (attr.content) {
-            return concatenate(transform(attr.content));
+            return traverse(transform(attr.content)).map(function(node) {
+                if (this.isLeaf) {
+                    return;
+                }
+
+                if (this.isRoot || node.type === 'ArrayExpression') {
+                    var elements = this.isRoot ? node : node.elements;
+
+                    this.after(function() {
+                        this.update(concatenate(elements), true);
+                    });
+                }
+            });
         }
 
         if (attr.value.type === 'Expression' && attr.value.content.type === 'ConditionalExpression') {

--- a/test/attributes/output.html
+++ b/test/attributes/output.html
@@ -56,7 +56,7 @@
  <div   data-default="true">Default content</div>
 
 
- <div style="background: red">
+ <div style="background: red" class="div-b-class">
  <form action="/login" method="POST">
  <label for="login" data-for="login">
  <span class="icon-user" role="presentation"></span>

--- a/test/attributes/template.js
+++ b/test/attributes/template.js
@@ -431,7 +431,17 @@ return function (h, options) {
                 return acc;
             }, []),
             '\n\n ',
-            h('div', { 'attributes': { 'style': 'background: red' } }, [
+            h('div', {
+                'attributes': {
+                    'style': 'background: red',
+                    'class': lookupValueWithFallback('class_name') ? function () {
+                        return [
+                            'div-',
+                            lookupValueWithFallback('class_name')
+                        ].join('');
+                    }() : null
+                }
+            }, [
                 '\n ',
                 h('form', {
                     'attributes': {

--- a/test/attributes/template.tmpl
+++ b/test/attributes/template.tmpl
@@ -45,7 +45,7 @@
             ><TMPL_VAR div.content></div>
     </TMPL_FOR>
 
-    <div style="background: red">
+    <div style="background: red" class="<TMPL_IF class_name>div-<TMPL_VAR class_name></TMPL_IF>">
         <form action="/login" method="POST">
             <label for="login" data-for="login">
                 <span class="icon-user" role="presentation"></span>

--- a/test/basic/template.js
+++ b/test/basic/template.js
@@ -354,7 +354,7 @@ return function (h, options) {
                                 'class': [
                                     'item ',
                                     lookupValueWithFallback('active') ? function () {
-                                        return ['item--active'];
+                                        return 'item--active';
                                     }() : null
                                 ].join('')
                             }

--- a/test/perl-expression-2/template.js
+++ b/test/perl-expression-2/template.js
@@ -347,9 +347,9 @@ return function (h, options) {
                                     'className': [
                                         '\n notification\n                    ',
                                         String(lookupValueWithFallback('type')) === 'warning' ? function () {
-                                            return ['\n notification--warning\n                    '];
+                                            return '\n notification--warning\n                    ';
                                         }() : String(lookupValueWithFallback('type')) === 'urgent' ? function () {
-                                            return ['\n notification--urgent\n                    '];
+                                            return '\n notification--urgent\n                    ';
                                         }() : null,
                                         '\n '
                                     ].join('')


### PR DESCRIPTION
Fixes attribute value generation in cases of nested TMPL_IF statements, for example:

```
<div class="<TMPL_IF class>btn-<TMPL_VAR class></TMPL_IF>"></div>
```

Before that would be rendered as

```
<div class="btn-,class_value"></div>
```
